### PR TITLE
Add configuration so you can develop in a VSCode dev container or Github Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,32 @@
+ARG VARIANT=latest
+FROM elixir:${VARIANT}
+
+# This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in
+# devcontainer.json to use it. More info: https://aka.ms/vscode-remote/containers/non-root-user.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Options for common package install script
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="true"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SHA="dev-mode"
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+RUN apt-get update \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y install --no-install-recommends curl ca-certificates 2>&1 \
+  && curl -sSL ${COMMON_SCRIPT_SOURCE} -o /tmp/common-setup.sh \
+  && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/common-setup.sh" | sha256sum -c -)) \
+  && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+
+  # Install instal hex and rebar
+  && apt-get install -y build-essential \
+  && mix local.hex --force \
+  && mix local.rebar --force \
+
+  # Clean up
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* /tmp/common-setup.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+	"name": "Elixir",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update 'VARIANT' to pick a Elixir version: 1.10
+			"VARIANT": "1.7.3",
+		}
+	},
+	"service": "elixir",
+	"workspaceFolder": "/workspace",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/zsh"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": ["jakebecker.elixir-ls"],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [4000, 4001],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "mix deps.get"
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update 'VARIANT' to pick a Elixir version: 1.10
-			"VARIANT": "1.7.3",
+			"VARIANT": "latest",
 		}
 	},
 	// "workspaceFolder": "/workspace",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [4000, 4001],
+	// "forwardPorts": [4000, 4001],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "mix deps.get"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 			"VARIANT": "1.7.3",
 		}
 	},
-	"workspaceFolder": "/workspace",
+	// "workspaceFolder": "/workspace",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
 			"VARIANT": "1.7.3",
 		}
 	},
-	"service": "elixir",
 	"workspaceFolder": "/workspace",
 
 	// Set *default* container specific settings.json values on container create.
@@ -16,7 +15,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": ["jakebecker.elixir-ls"],
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [4000, 4001],

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ $ git init
     1. You can see progress of the build by clicking `Starting Dev Container (show log): Building image` that appears in bottom right corner
     1. During the build process it will also automatically run `mix deps.get`
 1. Once complete VS Code will connect your running Dev Container and will feel like your doing local development
+1. If you would like more information about VS Code Dev Containers check out the [dev container documentation](https://code.visualstudio.com/docs/remote/create-dev-container/?WT.mc_id=AZ-MVP-5003399)
 
 #### Compatible with Github Codespaces
 1. If you dont have Github Codespaces beta access, sign up for the beta https://github.com/features/codespaces/signup

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A batteries included starter pack for participating in [Advent of Code](https://
 
 ## Usage
 
-There are 25 modules, 25 tests, and 50 mix tasks. 
+There are 25 modules, 25 tests, and 50 mix tasks.
 
 1. Fill in the tests with the example solutions.
 1. Write your implementation.
@@ -29,7 +29,7 @@ defmodule AdventOfCode.Day01Test do
 
   @tag :skip # Make sure to remove to run your test.
   test "part1" do
-    input = nil 
+    input = nil
     result = part1(input)
 
     assert result
@@ -37,7 +37,7 @@ defmodule AdventOfCode.Day01Test do
 
   @tag :skip # Make sure to remove to run your test.
   test "part2" do
-    input = nil 
+    input = nil
     result = part2(input)
 
     assert result
@@ -62,7 +62,7 @@ defmodule Mix.Tasks.D01.P1 do
         |> part1()
         |> IO.inspect(label: "Part 1 Results")
   end
-end   
+end
 ```
 
 ## Installation
@@ -87,6 +87,7 @@ $ git init
     1. You can see progress of the build by clicking `Starting Dev Container (show log): Building image` that appears in bottom right corner
     1. During the build process it will also automatically run `mix deps.get`
 1. Once complete VS Code will connect your running Dev Container and will feel like your doing local development
+1. If you would like to use a specific version of Elixir change the `VARIANT` version in `.devcontainer/devcontainer.json`
 1. If you would like more information about VS Code Dev Containers check out the [dev container documentation](https://code.visualstudio.com/docs/remote/create-dev-container/?WT.mc_id=AZ-MVP-5003399)
 
 #### Compatible with Github Codespaces

--- a/README.md
+++ b/README.md
@@ -76,3 +76,20 @@ $ cd advent-of-code
 $ rm -rf .git
 $ git init
 ```
+### Get started coding with zero configuration
+
+#### Using Visual Studio Code
+
+1. [Install Docker Desktop](https://www.docker.com/products/docker-desktop)
+1. Open project directory in VS Code
+1. Press F1, and select `Remote-Containers: Reopen in Container...`
+1. Wait a few minutes as it pulls image down and builds Dev Conatiner Docker image (this should only need to happen once unless you modify the Dockerfile)
+    1. You can see progress of the build by clicking `Starting Dev Container (show log): Building image` that appears in bottom right corner
+    1. During the build process it will also automatically run `mix deps.get`
+1. Once complete VS Code will connect your running Dev Container and will feel like your doing local development
+
+#### Compatible with Github Codespaces
+1. If you dont have Github Codespaces beta access, sign up for the beta https://github.com/features/codespaces/signup
+1. On GitHub, navigate to the main page of the repository.
+1. Under the repository name, use the  Code drop-down menu, and select Open with Codespaces.
+1. If you already have a codespace for the branch, click  New codespace.

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
+}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,0 @@
-%{
-  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
-  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
-}


### PR DESCRIPTION
I hope you dont mind this addition. I wanted to make it even easier for someone to get this project up and running at start hacking away at AoC problem by simplifying this environment setup.

This change creates a build of an Elixir docker image with pre-installed packages for everyday development. Then using the `devcontainer.json` file, you can either have Visual Studio Code build and SSH the Docker image locally to start coding away or launch the project in Github Codespaces and work in the cloud. No need to install anything locally since its all inside the Docker image and development is done in the running container.

Let me know what you think.